### PR TITLE
reconnect mysql on disconnect

### DIFF
--- a/lib/dbs/mysql.ts
+++ b/lib/dbs/mysql.ts
@@ -19,7 +19,6 @@ connection.on('error', function (err) {
     // Reconnect to DB on server disconnect
     // https://github.com/mysqljs/mysql#server-disconnects
     if (err.code === 'PROTOCOL_CONNECTION_LOST') {
-        console.log('Detected mysql disconnect. Attempting reconnection.');
         connection = mysql.createConnection(process.env.CLEARDB_DATABASE_URL ? process.env.CLEARDB_DATABASE_URL : MYSQL_CONFIG);
         query = promisify(connection.query.bind(connection));
     }


### PR DESCRIPTION
## What?
Reconnect to mysql db on disconnect

## Why?
The application did not handle errors from mysql resulting in an app crash upon server disconnects. Deploying to heroku with the ClearDB defined in app.json resulted in regular app crashes eventually resulting in a failure to load the app.

## Testing / Proof
...
Prior to implementing, the following error would be present in logs locally:
```
error - uncaughtException: Error: Connection lost: The server closed the connection.
    at Protocol.end (/Users/patrick.puente/node-projects/demo-tax-provider/node_modules/mysql/lib/protocol/Protocol.js:112:13)
    at Socket.<anonymous> (/Users/patrick.puente/node-projects/demo-tax-provider/node_modules/mysql/lib/Connection.js:94:28)
    at Socket.<anonymous> (/Users/patrick.puente/node-projects/demo-tax-provider/node_modules/mysql/lib/Connection.js:526:10)
    at Socket.emit (events.js:412:35)
    at Socket.emit (domain.js:470:12)
    at endReadableNT (internal/streams/readable.js:1317:12)
    at processTicksAndRejections (internal/process/task_queues.js:82:21) {
  fatal: true,
  code: 'PROTOCOL_CONNECTION_LOST'
}
```

In heroku logs, the error above was follwed by...
```
2021-12-30T19:47:14.170242+00:00 heroku[web.1]: Process exited with status 1
2021-12-30T19:47:14.222784+00:00 heroku[web.1]: State changed from up to crashed
```

after implementing, the error is no longer present locally and the logs show this instead:
```
Detected mysql disconnect. Attempting reconnection.
```
