### PR TITLE
total_tax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,5 +104,7 @@ dist
 .tern-port
 
 # ngrok
-
 ngrok
+
+# notes and ideas
+.idea

--- a/pages/api/tax/estimate.ts
+++ b/pages/api/tax/estimate.ts
@@ -7,20 +7,24 @@ const calculateTax = (item: EstimateRequestDocumentItem): EstimateResponseDocume
     const { id, price, tax_exempt, type, tax_class, quantity} = item
     const { tax_inclusive, amount } = price
     const taxRate = .1
+    const amount_inclusive = tax_exempt
+        ? amount
+        : tax_inclusive
+            ? amount * quantity
+            : (amount + (amount * taxRate)) * quantity
+    const amount_exclusive = tax_exempt
+        ? amount * quantity
+        : tax_inclusive
+            ? (amount / (1 + taxRate)) * quantity
+            : amount * quantity
+    const total_tax = amount_inclusive - amount_exclusive
 
     return {
         id,
         price: {
-            amount_inclusive: tax_exempt
-                ? amount
-                : tax_inclusive
-                    ? amount * quantity
-                    : (amount + (amount * taxRate)) * quantity,
-            amount_exclusive: tax_exempt
-                ? amount * quantity
-                : tax_inclusive
-                    ? (amount / (1 + taxRate)) * quantity
-                    : amount * quantity,
+            amount_inclusive, 
+            amount_exclusive,
+            total_tax,
             tax_rate: taxRate,
             sales_tax_summary: [
                 {

--- a/types/estimate.ts
+++ b/types/estimate.ts
@@ -82,6 +82,7 @@ export interface EstimateResponseTaxSummaryItem {
 export interface EstimateResponseDocumentPrice {
     amount_inclusive: number;
     amount_exclusive: number;
+    total_tax: number;
     tax_rate: number;
     sales_tax_summary: EstimateResponseTaxSummaryItem[]
 }


### PR DESCRIPTION
## What?
Adds total_tax to prices in the estimate response.

## Why?
Because it's required and I missed it initially resulting in errors when the app started receiving estimate requests from BC.

## Testing / Proof
Estimate responses generated locally with using Postman now include total_tax
