### PR TITLE
remove quantity from sales_tax_summary

### DIFF
--- a/pages/api/tax/estimate.ts
+++ b/pages/api/tax/estimate.ts
@@ -30,7 +30,7 @@ const calculateTax = (item: EstimateRequestDocumentItem): EstimateResponseDocume
                 {
                     name: 'Hardcoded Tax Rate',
                     rate: taxRate,
-                    amount: total_tax * quantity,
+                    amount: total_tax,
                     tax_class,
                     id: 'Hardcoded Tax Rate ID'
                 }


### PR DESCRIPTION
## What?
Removed quantity from sales_tax_summary

## Why?
BC expects the sum of sales_tax_summary[n].amount to equal total_tax

## Testing / Proof
Quantity is no longer part of the calculation when testing locally
