### PR TITLE
fix #12

### DIFF
--- a/pages/api/tax/estimate.ts
+++ b/pages/api/tax/estimate.ts
@@ -65,13 +65,15 @@ const calculateTax = (item: EstimateRequestDocumentItem): EstimateResponseDocume
     const amount_inclusive = round(tax_exempt
         ? amount
         : tax_inclusive
-            ? amount * quantity
-            : (amount + (amount * taxRate)) * quantity, 2)
+            ? amount
+            : amount + (amount * taxRate)
+        , 2)
     const amount_exclusive = round(tax_exempt
         ? amount * quantity
         : tax_inclusive
-            ? (amount / (1 + taxRate)) * quantity
-            : amount * quantity, 2)
+            ? amount / (1 + taxRate)
+            : amount
+        , 2)
     const total_tax = round(amount_inclusive - amount_exclusive, 2)
 
     return {


### PR DESCRIPTION
## What?
Fix #12 - Removes quantity from line item tax calculations

## Why?
BC already multiplies price by quantity in the rate request

## Testing / Proof
Prior to this fix, the tax_exclusive amount returned by the app was greater than the line item price provided by BC resulting in this error in the store logs and fallback tax when the cart contained an item with quantity > 1:

> Tax quote rejected. Your configured tax provider returned a quote with an invalid amount

After the fix, the app correctly accepts the price from BC as having already accounted for quantity and returns a valid quote which is applied to the cart/checkout.