### PR TITLE
getCart

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,10 @@ To simulate a delay in response, pass a string in the format `DELAY:TIME_IN_MS` 
 
 As an attempt to debug an issue, the app may query BigCommerce for the checkout corresponding to a tax rate request before responding to the request by passing a string in the format `GET_CHECKOUT_BEFORE:HASH` where `HASH` is the unique store hash for the store that generated the estimate request. The app may make the same query after responding to the rate request by passing a string in the format `GET_CHECKOUT_AFTER:HASH`
 
+### Query Carts
+
+As an attempt to debug an issue, the app may query BigCommerce for the cart corresponding to a tax rate request before responding to the request by passing a string in the format `GET_CART_BEFORE:HASH` where `HASH` is the unique store hash for the store that generated the estimate request. The app may make the same query after responding to the rate request by passing a string in the format `GET_CART_AFTER:HASH`
+
   
 ## Usage with BigCommerce
 

--- a/lib/cartApi.ts
+++ b/lib/cartApi.ts
@@ -1,0 +1,26 @@
+import { pino } from 'pino'
+import { bigcommerceClient } from './auth'
+import db from './db'
+
+const logger = pino({
+    transport: {
+        target: 'pino-pretty',
+        options: { destination: 1 }
+    }
+})
+
+export async function getCart(storeHash: string, cartId: string) {
+    try {
+        const token = await db.getStoreToken(storeHash)
+        const bigCommerce = await bigcommerceClient(token, storeHash)
+
+        const checkout = await bigCommerce.get(`/carts/${cartId}`)
+        logger.info(`Cart response for ${cartId}: ${JSON.stringify(checkout)}`)
+
+        return checkout
+    } catch (err) {
+        logger.error(`Error getting cart: ${err}`)
+
+        return
+    }
+}

--- a/types/estimate.ts
+++ b/types/estimate.ts
@@ -106,3 +106,11 @@ export interface EstimateResponse {
     id: string;
     documents: EstimateResponseDocument[]
 }
+
+export enum EstimateAction {
+    GET_CHECKOUT_BEFORE = "GET_CHECKOUT_BEFORE",
+    GET_CHECKOUT_AFTER = "GET_CHECKOUT_AFTER",
+    GET_CART_BEFORE = "GET_CART_BEFORE",
+    GET_CART_AFTER = "GET_CART_AFTER",
+    SLEEP = "DELAY",
+}


### PR DESCRIPTION
As an attempt to debug an issue, the app may query BigCommerce for the cart corresponding to a tax rate request before responding to the request by passing a string in the format `GET_CART_BEFORE:HASH` where `HASH` is the unique store hash for the store that generated the estimate request. The app may make the same query after responding to the rate request by passing a string in the format `GET_CART_AFTER:HASH`